### PR TITLE
Fix executable config

### DIFF
--- a/sensu-plugins-postfix.gemspec
+++ b/sensu-plugins-postfix.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.date                   = Date.today.to_s
   s.description            = 'Sensu plugins for postfix'
   s.email                  = '<sensu-users@googlegroups.com>'
-  s.executables            = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  s.executables            = Dir.glob('bin/**/*').map { |file| File.basename(file) }
   s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-postfix'
   s.license                = 'MIT'


### PR DESCRIPTION
In the current version of the gemspec the configuration of the executables does not work. Symptom: they are not copied to `/opt/sensu/embedded/bin/` as all the other executables of other plugins are.

This change fixes the configuration.
