### PR TITLE
Expand and add additional queue checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ mkmf.log
 .DS_Store
 .idea/*
 *.gem
+.kitchen

--- a/.kitchen.travis.yml
+++ b/.kitchen.travis.yml
@@ -1,0 +1,2 @@
+driver:
+  name: localhost

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,17 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: shell
+  data_path: .
+  script: test/fixtures/bootstrap.sh
+
+verifier:
+  ruby_bindir: /opt/sensu/embedded/bin
+
+platforms:
+  - name: ubuntu-14.04
+
+suites:
+  - name: default

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+sudo: required
+dist: trusty
 cache:
   - bundler
 install:
@@ -17,3 +19,7 @@ notifications:
 
 script:
   - 'bundle exec rake default'
+  - 'bundle exec kitchen test'
+
+env:
+  - KITCHEN_LOCAL_YAML=.kitchen.travis.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## Unreleased
+### Added
+- Add support to `check-mailq` for inspecting each Postfix queue individually
+- Add a `check-mail-delay` script to support alerting by age of queue items
 
 ## [0.0.3] - 2015-07-14
 ### Changed

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 ## Files
  * bin/check-mailq.rb
+ * bin/check-mail-delay.rb
  * bin/metrics-mailq.rb
 
 ## Usage

--- a/bin/check-mail-delay.rb
+++ b/bin/check-mail-delay.rb
@@ -1,0 +1,173 @@
+#!/usr/bin/env ruby
+#
+#   check-mail-delay
+#
+# DESCRIPTION:
+#   Check for mail delays in the Postfix mail queue
+#
+# OUTPUT:
+#   Plain text
+#
+# PLATFORMS:
+#   Linux; any platform with Postfix, egrep, and awk
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#
+# USAGE:
+#   ./check-mail-delay.rb [-p path_to_mailq] [-q queue] [-d delay] -w warn -c crit
+#   ./check-mail-delay.rb -w 100 -c 200
+#   ./check-mail-delay.rb -q hold -w 50 -c 100
+#   ./check-mail-delay.rb -q deferred -d 7200 -w 10 -c 20
+#   ./check-mail-delay.rb -p /usr/local/bin/mailq -q active -d 300 -w 100 -c 200
+#
+# NOTES:
+#   This is split out into its own check because, unlike `check-mailq`, it
+#   requires storing details about every message in the queue in memory, which
+#   may not be desirable on heavily-trafficked systems.
+#
+# LICENSE:
+#   Jonathan Hartman <j@hartman.io>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'date'
+require 'sensu-plugin/check/cli'
+
+class PostfixMailDelay < Sensu::Plugin::Check::CLI
+  option :path,
+         short: '-p MAILQ_PATH',
+         long: '--path MAILQ_PATH',
+         description: 'Path to the postfix mailq binary.  Defaults to /usr/bin/mailq',
+         default: '/usr/bin/mailq'
+
+  option :queue,
+         short: '-q QUEUE_NAME',
+         long: '--queue QUEUE_NAME',
+         description: 'The queue to check (active, deferred, hold, ' \
+                      "incoming, or all). Defaults to 'all'",
+         default: 'all'
+
+  option :delay,
+         short: '-d DELAY_IN_SECONDS',
+         long: '--delay DELAY_IN_SECONDS',
+         description: 'Age in seconds of messages to look for',
+         default: 3600
+
+  option :warning,
+         short: '-w WARN_NUM',
+         long: '--warnnum WARN_NUM',
+         description: 'Number of delayed messages considered a worth a warning',
+         required: true
+
+  option :critical,
+         short: '-c CRIT_NUM',
+         long: '--critnum CRIT_NUM',
+         description: 'Number of delayed messages considered to be critical',
+         required: true
+
+  def run
+    count = 0
+    timestamps = send("queue_data_#{config[:queue]}")
+    timestamps.each do |t|
+      count += 1 if check_age_of(t) > config[:delay].to_i
+    end
+
+    msg = "#{count} messages in the postfix " \
+          "#{config[:queue] == 'all' ? 'mail' : config[:queue]} queue older " \
+          "than #{config[:delay]} seconds"
+
+    if count >= config[:critical].to_i
+      critical msg
+    elsif count >= config[:warning].to_i
+      warning msg
+    else
+      ok msg
+    end
+  end
+
+  #
+  # Parse a timestamp from the output of `mailq` and return that message's
+  # age in seconds. The `mailq` command does not insert years in its output,
+  # so we're going to make the (hopefully valid) assumption that there won't
+  # be any queue items older than a year and just subtract one year if a queue
+  # item appears to be from the future.
+  #
+  def check_age_of(timestamp)
+    d = DateTime.parse("#{timestamp} #{DateTime.now.zone}")
+    now = DateTime.now
+    d = d.prev_year if d > now
+    (now.to_time - d.to_time).to_i
+  end
+
+  #
+  # Return an array of timestamps for every message in the queue.
+  #
+  # `mailq` will either end with a summary line (-- 11 Kbytes in 31 Requests.)
+  # or 'Mail queue is empty'.  Using grep rather than returning the entire
+  # list since that could consume a significant amount of memory.
+  #
+  def queue_data_all
+    queue = `#{config[:path]} | /bin/egrep '^[0-9A-F]+' | awk '{print $3, $4, $5, $6}'`
+    queue.split("\n")
+  end
+
+  #
+  # Return an array of timestamps for messages in the active queue.
+  #
+  # Items in the active queue appear with a '*' next to the QID in `mailq`
+  #
+  def queue_data_active
+    queue = `#{config[:path]} | /bin/egrep '^[0-9A-F]+\\*' | awk '{print $3, $4, $5, $6}'`
+    queue.split("\n")
+  end
+
+  #
+  # Return an array of timestamps for messages in the deferred queue.
+  #
+  # Items in the deferred queue do not have a special indicator in `mailq`,
+  # but are followed by lines with deferral reasons in ()s.
+  #
+  def queue_data_deferred
+    output = `#{config[:path]} | /bin/egrep -A 1 '^[0-9A-F]+ +'`.split("\n--\n")
+    queue = []
+    output.each do |o|
+      if o.lines[1].strip.match(/^\(.*\)$/)
+        fields = o.lines[0].split
+        queue << "#{fields[2]} #{fields[3]} #{fields[4]} #{fields[5]}"
+      end
+    end
+    queue
+  end
+
+  #
+  # Return an array of timestamps for messages in the hold queue.
+  #
+  # Items in the hold queue appear with a '!' next to the QID in `mailq`.
+  #
+  def queue_data_hold
+    queue = `#{config[:path]} | /bin/egrep '^[0-9A-F]+!' | awk '{print $3, $4, $5, $6}'`
+    queue.split("\n")
+  end
+
+  #
+  # Return an array of timestamps for messages in the incoming queue.
+  #
+  # Items in the incoming queue have no special character indicating as much in
+  # `mailq`. Inspecting `/var/spool/postfix` directly requires root or postfix
+  # user permissions, so we have to get a little tricky here and find any queue
+  # item with no special character and that's not followed by a deferal line.
+  #
+  def queue_data_incoming
+    output = `#{config[:path]} | /bin/egrep -A 1 '^[0-9A-F]+ +'`.split("\n--\n")
+    queue = []
+    output.each do |o|
+      unless o.lines[1].strip.match(/^\(.*\)$/)
+        fields = o.lines[0].split
+        queue << "#{fields[2]} #{fields[3]} #{fields[4]} #{fields[5]}"
+      end
+    end
+    queue
+  end
+end

--- a/bin/check-mailq.rb
+++ b/bin/check-mailq.rb
@@ -1,12 +1,35 @@
 #!/usr/bin/env ruby
 #
-# Check the size of the postfix mail queue
-# ===
+#   check-mailq
 #
-# Copyright (c) 2013, Justin Lambert <jlambert@letsevenup.com>
+# DESCRIPTION:
+#   Check the size of the Postfix mail queue
 #
-# Released under the same terms as Sensu (the MIT license); see LICENSE
-# for details.
+# OUTPUT:
+#   Plain text
+#
+# PLATFORMS:
+#   Linux; any platform with Postfix and egrep
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#
+# USAGE:
+#   ./check-mailq.rb [-p path_to_mailq] [-q queue] -w warn -c crit
+#   ./check-mailq.rb -w 200 -c 400
+#   ./check-mailq.rb -q deferred -w 100 -c 200
+#   ./check-mailq.rb -p /usr/local/bin/mailq -q active -w 50 -c 100
+#
+# NOTES:
+#   This is split out into its own check because, unlike `check-mailq`, it
+#   requires storing details about every message in the queue in memory, which
+#   may not be desirable on heavily-trafficked systems.
+#
+# LICENSE:
+#   Justin Lambert <jlambert@letsevenup.com>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
 
 require 'sensu-plugin/check/cli'
 
@@ -16,6 +39,13 @@ class PostfixMailq < Sensu::Plugin::Check::CLI
          long: '--path MAILQ_PATH',
          description: 'Path to the postfix mailq binary.  Defaults to /usr/bin/mailq',
          default: '/usr/bin/mailq'
+
+  option :queue,
+         short: '-q QUEUE_NAME',
+         long: '--queue QUEUE_NAME',
+         description: 'The queue to check (active, deferred, hold, ' \
+                      "incoming, or all). Defaults to 'all'",
+         default: 'all'
 
   option :warning,
          short: '-w WARN_NUM',
@@ -30,24 +60,60 @@ class PostfixMailq < Sensu::Plugin::Check::CLI
          required: true
 
   def run
-    # mailq will either end with a summary line (-- 11 Kbytes in 31 Requests.)
-    # or 'Mail queue is empty'.  Using grep rather than returning the entire
-    # list since that could consume a significant amount of memory.
-    queue = `#{config[:path]} | /bin/egrep '[0-9]+ Kbytes in [0-9]+ Request\|Mail queue is empty'`
-
-    # Set the number of messages in the queue
-    if queue == 'Mail queue is empty'
-      num_messages = 0
-    else
-      num_messages = queue.split(' ')[4].to_i
-    end
+    num_messages = send("check_queue_size_#{config[:queue]}")
+    msg = "#{num_messages} messages in the postfix #{config[:queue] == 'all' ? 'mail' : config[:queue]} queue"
 
     if num_messages >= config[:critical].to_i
-      critical "#{num_messages} messages in the postfix mail queue"
+      critical msg
     elsif num_messages >= config[:warning].to_i
-      warning "#{num_messages} messages in the postfix mail queue"
+      warning msg
     else
-      ok "#{num_messages} messages in the postfix mail queue"
+      ok msg
     end
+  end
+
+  #
+  # Return the number of messages in all the queues.
+  #
+  # `mailq` will either end with a summary line (-- 11 Kbytes in 31 Requests.)
+  # or 'Mail queue is empty'.  Using grep rather than returning the entire
+  # list since that could consume a significant amount of memory.
+  #
+  def check_queue_size_all
+    queue = `#{config[:path]} | /bin/egrep '[0-9]+ Kbytes in [0-9]+ Request\|Mail queue is empty'`
+    queue == 'Mail queue is empty' ? 0 : queue.split(' ')[4].to_i
+  end
+
+  #
+  # Items in the active queue appear with a '*' next to the QID in `mailq`
+  #
+  def check_queue_size_active
+    `#{config[:path]} | /bin/egrep -c '^[0-9A-F]+\\*'`.to_i
+  end
+
+  #
+  # Items in the deferred queue do not have a special indicator in `mailq`,
+  # but are followed by lines with deferral reasons in ()s.
+  #
+  def check_queue_size_deferred
+    `#{config[:path]} | /bin/grep -c '^ *(.*)$'`.to_i
+  end
+
+  #
+  # Items in the hold queue appear with a '!' next to the QID in `mailq`.
+  #
+  def check_queue_size_hold
+    `#{config[:path]} | /bin/egrep -c '^[0-9A-F]+!'`.to_i
+  end
+
+  #
+  # Items in the incoming queue have no special character indicating as much in
+  # `mailq`. Inspecting `/var/spool/postfix` directly requires root or postfix
+  # user permissions, so let's try to be crafty and subtract the number of
+  # deferred messages from the total number of messages with no special
+  # character appended to their QID.
+  #
+  def check_queue_size_incoming
+    `#{config[:path]} | /bin/egrep -c '^[0-9A-F]+ +'`.to_i - check_queue_size_deferred
   end
 end

--- a/sensu-plugins-postfix.gemspec
+++ b/sensu-plugins-postfix.gemspec
@@ -52,4 +52,5 @@ Gem::Specification.new do |s|
   # Hold back net-ssh to a version compatible with Ruby 1.9
   s.add_development_dependency 'net-ssh',                   '~> 2.9'
   s.add_development_dependency 'kitchen-vagrant',           '~> 0.19.0'
+  s.add_development_dependency 'kitchen-localhost',         '~> 0.3'
 end

--- a/sensu-plugins-postfix.gemspec
+++ b/sensu-plugins-postfix.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
   s.required_ruby_version  = '>= 1.9.3'
-  s.signing_key            = File.expand_path(pvt_key) if $PROGRAM_NAME =~ /gem\z/
+  s.signing_key            = File.expand_path(pvt_key) if $PROGRAM_NAME =~ /gem\z/ && ENV['SIGN_GEM'] != 'false'
   s.summary                = 'Sensu plugins for postfix'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsPostfix::Version::VER_STRING
@@ -48,4 +48,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec',                     '~> 3.1'
   s.add_development_dependency 'rubocop',                   '0.32.1'
   s.add_development_dependency 'yard',                      '~> 0.8'
+  s.add_development_dependency 'test-kitchen',              '~> 1.5'
+  # Hold back net-ssh to a version compatible with Ruby 1.9
+  s.add_development_dependency 'net-ssh',                   '~> 2.9'
+  s.add_development_dependency 'kitchen-vagrant',           '~> 0.19.0'
 end

--- a/test/fixtures/bootstrap.sh
+++ b/test/fixtures/bootstrap.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+#
+# Set up a super simple Postfix server and block its outbound port 25 so we can
+# use it for testing.
+#
+
+DATA_DIR=/tmp/kitchen/data
+SENSU_DIR=/opt/sensu
+GEM=$SENSU_DIR/embedded/bin/gem
+RUBY=$SENSU_DIR/embedded/bin/ruby
+CHECK_MAILQ="$SENSU_DIR/embedded/bin/check-mailq.rb"
+METRICS_MAILQ="$SENSU_DIR/embedded/bin/metrics-mailq.rb"
+
+if [ ! -d $SENSU_DIR ]; then
+  wget -q http://repositories.sensuapp.org/apt/pubkey.gpg -O- | sudo apt-key add -
+  echo "deb http://repositories.sensuapp.org/apt sensu main" | sudo tee /etc/apt/sources.list.d/sensu.list
+
+  sudo apt-get update
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git vim postfix mailutils sensu
+  sudo iptables -I OUTPUT -m tcp -p tcp --dport 25 -j DROP
+fi
+
+cd $DATA_DIR
+SIGN_GEM=false $GEM build sensu-plugins-postfix.gemspec
+sudo sensu-install -p sensu-plugins-postfix-*.gem
+
+$CHECK_MAILQ -w 1 -c 2
+$CHECK_MAILQ -q all -w 1 -c 2
+$CHECK_MAILQ -q active -w 1 -c 2
+$CHECK_MAILQ -q deferred -w 1 -c 2
+$CHECK_MAILQ -q hold -w 1 -c 2
+$CHECK_MAILQ -q incoming -w 1 -c 2

--- a/test/fixtures/bootstrap.sh
+++ b/test/fixtures/bootstrap.sh
@@ -8,8 +8,6 @@ DATA_DIR=/tmp/kitchen/data
 SENSU_DIR=/opt/sensu
 GEM=$SENSU_DIR/embedded/bin/gem
 RUBY=$SENSU_DIR/embedded/bin/ruby
-CHECK_MAILQ="$SENSU_DIR/embedded/bin/check-mailq.rb"
-METRICS_MAILQ="$SENSU_DIR/embedded/bin/metrics-mailq.rb"
 
 if [ ! -d $SENSU_DIR ]; then
   wget -q http://repositories.sensuapp.org/apt/pubkey.gpg -O- | sudo apt-key add -
@@ -23,10 +21,3 @@ fi
 cd $DATA_DIR
 SIGN_GEM=false $GEM build sensu-plugins-postfix.gemspec
 sudo sensu-install -p sensu-plugins-postfix-*.gem
-
-$CHECK_MAILQ -w 1 -c 2
-$CHECK_MAILQ -q all -w 1 -c 2
-$CHECK_MAILQ -q active -w 1 -c 2
-$CHECK_MAILQ -q deferred -w 1 -c 2
-$CHECK_MAILQ -q hold -w 1 -c 2
-$CHECK_MAILQ -q incoming -w 1 -c 2

--- a/test/integration/default/bats/check-mail-delay.bats
+++ b/test/integration/default/bats/check-mail-delay.bats
@@ -1,0 +1,187 @@
+#!/usr/bin/env bats
+
+setup() {
+  export CHECK_MAIL_DELAY="sudo -u sensu /opt/sensu/embedded/bin/check-mail-delay.rb"
+}
+
+teardown() {
+  clear_queue
+  unset_connect_timeout
+  postfix reload
+}
+
+clear_queue() {
+  postsuper -d ALL
+}
+
+set_connect_timeout() {
+  echo "smtp_connect_timeout = $1" >> /etc/postfix/main.cf
+  postfix reload
+}
+
+unset_connect_timeout() {
+  sed -i '/^smtp_connect_timeout/d' /etc/postfix/main.cf
+  postfix reload
+}
+
+populate_queue() {
+  for n in `seq 1 $1`; do
+    echo pants | mail user$n@example.com
+  done
+}
+
+populate_hold_queue() {
+  populate_queue $1
+  postsuper -h ALL
+}
+
+populate_deferred_queue() {
+  set_connect_timeout 1
+  populate_queue $1
+  sleep 4
+  unset_connect_timeout
+}
+
+@test "Check default (all) queue, ok" {
+  populate_hold_queue 2
+  populate_queue 3
+  run $CHECK_MAIL_DELAY -w 10 -c 20
+  [ $status = 0 ]
+  [ "$output" = "PostfixMailDelay OK: 0 messages in the postfix mail queue older than 3600 seconds" ]
+}
+
+@test "Check default (all) queue, warning" {
+  populate_hold_queue 3
+  populate_queue 2
+  sleep 2
+  run $CHECK_MAIL_DELAY -d 1 -w 4 -c 20
+  [ $status = 1 ]
+  [ "$output" = "PostfixMailDelay WARNING: 5 messages in the postfix mail queue older than 1 seconds" ]
+}
+
+@test "Check default (all) queue, critical" {
+  populate_hold_queue 1
+  populate_queue 4
+  sleep 2
+  run $CHECK_MAIL_DELAY -d 1 -w 4 -c 5
+  [ $status = 2 ]
+  [ "$output" = "PostfixMailDelay CRITICAL: 5 messages in the postfix mail queue older than 1 seconds" ]
+}
+
+@test "Check all queues, ok" {
+  populate_hold_queue 3
+  populate_queue 2
+  run $CHECK_MAIL_DELAY -q all -w 10 -c 20
+  [ $status = 0 ]
+  [ "$output" = "PostfixMailDelay OK: 0 messages in the postfix mail queue older than 3600 seconds" ]
+}
+
+@test "Check all queues, warning" {
+  populate_hold_queue 3
+  populate_queue 2
+  sleep 2
+  run $CHECK_MAIL_DELAY -q all -d 1 -w 4 -c 20
+  [ $status = 1 ]
+  [ "$output" = "PostfixMailDelay WARNING: 5 messages in the postfix mail queue older than 1 seconds" ]
+}
+
+@test "Check all queues, critical" {
+  populate_hold_queue 3
+  populate_queue 2
+  sleep 2
+  run $CHECK_MAIL_DELAY -q all -d 1 -w 4 -c 5
+  [ $status = 2 ]
+  [ "$output" = "PostfixMailDelay CRITICAL: 5 messages in the postfix mail queue older than 1 seconds" ]
+}
+
+@test "Check active queue, ok" {
+  populate_hold_queue 10
+  populate_deferred_queue 1
+  populate_queue 5
+  run $CHECK_MAIL_DELAY -q active -w 10 -c 20
+  [ $status = 0 ]
+  [ "$output" = "PostfixMailDelay OK: 0 messages in the postfix active queue older than 3600 seconds" ]
+}
+
+@test "Check active queue, warning" {
+  populate_hold_queue 10
+  populate_queue 5
+  sleep 2
+  run $CHECK_MAIL_DELAY -q active -d 1 -w 4 -c 20
+  [ $status = 1 ]
+  [ "$output" = "PostfixMailDelay WARNING: 5 messages in the postfix active queue older than 1 seconds" ]
+}
+
+@test "Check active queue, critical" {
+  populate_hold_queue 10
+  populate_queue 5
+  sleep 2
+  run $CHECK_MAIL_DELAY -q active -d 1 -w 4 -c 5
+  [ $status = 2 ]
+  [ "$output" = "PostfixMailDelay CRITICAL: 5 messages in the postfix active queue older than 1 seconds" ]
+}
+
+# Not sure how to test the incoming queue more thoroughly
+@test "Check incoming queue, ok" {
+  populate_hold_queue 10
+  populate_queue 5
+  sleep 2
+  run $CHECK_MAIL_DELAY -q incoming -w 1 -c 1
+  [ $status = 0 ]
+  [ "$output" = "PostfixMailDelay OK: 0 messages in the postfix incoming queue older than 3600 seconds" ]
+}
+
+@test "Check deferred queue, ok" {
+  populate_hold_queue 10
+  populate_deferred_queue 2
+  populate_queue 1
+  run $CHECK_MAIL_DELAY -q deferred -w 5 -c 10
+  [ $status = 0 ]
+  [ "$output" = "PostfixMailDelay OK: 0 messages in the postfix deferred queue older than 3600 seconds" ]
+}
+
+@test "Check deferred queue, warning" {
+  populate_hold_queue 2
+  populate_deferred_queue 2
+  populate_queue 2
+  sleep 2
+  run $CHECK_MAIL_DELAY -q deferred -d 1 -w 2 -c 5
+  [ $status = 1 ]
+  [ "$output" = "PostfixMailDelay WARNING: 2 messages in the postfix deferred queue older than 1 seconds" ]
+}
+
+@test "Check deferred queue, critical" {
+  populate_hold_queue 2
+  populate_deferred_queue 3
+  populate_queue 2
+  sleep 2
+  run $CHECK_MAIL_DELAY -q deferred -d 1 -w 2 -c 3
+  [ $status = 2 ]
+  [ "$output" = "PostfixMailDelay CRITICAL: 3 messages in the postfix deferred queue older than 1 seconds" ]
+}
+
+@test "Check hold queue, ok" {
+  populate_hold_queue 5
+  populate_queue 2
+  run $CHECK_MAIL_DELAY -q hold -w 10 -c 20
+  [ $status = 0 ]
+  [ "$output" = "PostfixMailDelay OK: 0 messages in the postfix hold queue older than 3600 seconds" ]
+}
+
+@test "Check hold queue, warning" {
+  populate_hold_queue 5
+  populate_queue 2
+  sleep 2
+  run $CHECK_MAIL_DELAY -q hold -d 1 -w 4 -c 20
+  [ $status = 1 ]
+  [ "$output" = "PostfixMailDelay WARNING: 5 messages in the postfix hold queue older than 1 seconds" ]
+}
+
+@test "Check hold queue, critical" {
+  populate_hold_queue 10
+  populate_queue 2
+  sleep 2
+  run $CHECK_MAIL_DELAY -q hold -d 1 -w 5 -c 10
+  [ $status = 2 ]
+  [ "$output" = "PostfixMailDelay CRITICAL: 10 messages in the postfix hold queue older than 1 seconds" ]
+}

--- a/test/integration/default/bats/check-mailq.bats
+++ b/test/integration/default/bats/check-mailq.bats
@@ -1,0 +1,177 @@
+#!/usr/bin/env bats
+
+setup() {
+  export CHECK_MAILQ="sudo -u sensu /opt/sensu/embedded/bin/check-mailq.rb"
+}
+
+teardown() {
+  clear_queue
+  unset_connect_timeout
+  postfix reload
+}
+
+clear_queue() {
+  postsuper -d ALL
+}
+
+set_connect_timeout() {
+  echo "smtp_connect_timeout = $1" >> /etc/postfix/main.cf
+  postfix reload
+}
+
+unset_connect_timeout() {
+  sed -i '/^smtp_connect_timeout/d' /etc/postfix/main.cf
+  postfix reload
+}
+
+populate_queue() {
+  for n in `seq 1 $1`; do
+    echo pants | mail user$n@example.com
+  done
+}
+
+populate_hold_queue() {
+  populate_queue $1
+  postsuper -h ALL
+}
+
+populate_deferred_queue() {
+  set_connect_timeout 1
+  populate_queue $1
+  sleep 4
+  unset_connect_timeout
+}
+
+@test "Check default (all) queue, ok" {
+  populate_hold_queue 2
+  populate_queue 3
+  run $CHECK_MAILQ -w 10 -c 20
+  [ $status = 0 ]
+  [ "$output" = "PostfixMailq OK: 5 messages in the postfix mail queue" ]
+}
+
+@test "Check default (all) queue, warning" {
+  populate_hold_queue 3
+  populate_queue 2
+  run $CHECK_MAILQ -w 4 -c 20
+  [ $status = 1 ]
+  [ "$output" = "PostfixMailq WARNING: 5 messages in the postfix mail queue" ]
+}
+
+@test "Check default (all) queue, critical" {
+  populate_hold_queue 1
+  populate_queue 4
+  run $CHECK_MAILQ -w 4 -c 5
+  [ $status = 2 ]
+  [ "$output" = "PostfixMailq CRITICAL: 5 messages in the postfix mail queue" ]
+}
+
+@test "Check all queues, ok" {
+  populate_hold_queue 3
+  populate_queue 2
+  run $CHECK_MAILQ -q all -w 10 -c 20
+  [ $status = 0 ]
+  [ "$output" = "PostfixMailq OK: 5 messages in the postfix mail queue" ]
+}
+
+@test "Check all queues, warning" {
+  populate_hold_queue 3
+  populate_queue 2
+  run $CHECK_MAILQ -q all -w 4 -c 20
+  [ $status = 1 ]
+  [ "$output" = "PostfixMailq WARNING: 5 messages in the postfix mail queue" ]
+}
+
+@test "Check all queues, critical" {
+  populate_hold_queue 3
+  populate_queue 2
+  run $CHECK_MAILQ -q all -w 4 -c 5
+  [ $status = 2 ]
+  [ "$output" = "PostfixMailq CRITICAL: 5 messages in the postfix mail queue" ]
+}
+
+@test "Check active queue, ok" {
+  populate_hold_queue 10
+  populate_deferred_queue 1
+  populate_queue 5
+  run $CHECK_MAILQ -q active -w 10 -c 20
+  [ $status = 0 ]
+  [ "$output" = "PostfixMailq OK: 5 messages in the postfix active queue" ]
+}
+
+@test "Check active queue, warning" {
+  populate_hold_queue 10
+  populate_queue 5
+  run $CHECK_MAILQ -q active -w 4 -c 20
+  [ $status = 1 ]
+  [ "$output" = "PostfixMailq WARNING: 5 messages in the postfix active queue" ]
+}
+
+@test "Check active queue, critical" {
+  populate_hold_queue 10
+  populate_queue 5
+  run $CHECK_MAILQ -q active -w 4 -c 5
+  [ $status = 2 ]
+  [ "$output" = "PostfixMailq CRITICAL: 5 messages in the postfix active queue" ]
+}
+
+# Not sure how to test the incoming queue more thoroughly
+@test "Check incoming queue, ok" {
+  populate_hold_queue 10
+  populate_queue 5
+  sleep 1
+  run $CHECK_MAILQ -q incoming -w 1 -c 1
+  [ $status = 0 ]
+  [ "$output" = "PostfixMailq OK: 0 messages in the postfix incoming queue" ]
+}
+
+@test "Check deferred queue, ok" {
+  populate_hold_queue 10
+  populate_deferred_queue 2
+  populate_queue 1
+  run $CHECK_MAILQ -q deferred -w 5 -c 10
+  [ $status = 0 ]
+  [ "$output" = "PostfixMailq OK: 2 messages in the postfix deferred queue" ]
+}
+
+@test "Check deferred queue, warning" {
+  populate_hold_queue 2
+  populate_deferred_queue 2
+  populate_queue 2
+  run $CHECK_MAILQ -q deferred -w 2 -c 5
+  [ $status = 1 ]
+  [ "$output" = "PostfixMailq WARNING: 2 messages in the postfix deferred queue" ]
+}
+
+@test "Check deferred queue, critical" {
+  populate_hold_queue 2
+  populate_deferred_queue 3
+  populate_queue 2
+  run $CHECK_MAILQ -q deferred -w 2 -c 3
+  [ $status = 2 ]
+  [ "$output" = "PostfixMailq CRITICAL: 3 messages in the postfix deferred queue" ]
+}
+
+@test "Check hold queue, ok" {
+  populate_hold_queue 5
+  populate_queue 2
+  run $CHECK_MAILQ -q hold -w 10 -c 20
+  [ $status = 0 ]
+  [ "$output" = "PostfixMailq OK: 5 messages in the postfix hold queue" ]
+}
+
+@test "Check hold queue, warning" {
+  populate_hold_queue 5
+  populate_queue 2
+  run $CHECK_MAILQ -q hold -w 4 -c 20
+  [ $status = 1 ]
+  [ "$output" = "PostfixMailq WARNING: 5 messages in the postfix hold queue" ]
+}
+
+@test "Check hold queue, critical" {
+  populate_hold_queue 10
+  populate_queue 2
+  run $CHECK_MAILQ -q hold -w 5 -c 10
+  [ $status = 2 ]
+  [ "$output" = "PostfixMailq CRITICAL: 10 messages in the postfix hold queue" ]
+}


### PR DESCRIPTION
This proposed change would update the `check-mailq` script with the ability to inspect each Postfix queue (active, deferred, hold...) individually in addition to overall quantity of messages. It maintains the same counts and output messages of the currently released version if no queue is specified.

It also adds a `check-mail-delay` script that can inspect timestamps on messages in the queues and alert based on there being too many messages older than a specified number of seconds.

I added some basic testing for both of the check scripts via Test Kitchen and some BATS, but didn't go as far as adding them to the Travis build config, though that could certainly be done too.

If there are any questions/comments/concerns, just let me know. Thanks for looking!
