### PR TITLE
Get the CI tests passing again

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,7 +8,7 @@ provisioner:
   script: test/fixtures/bootstrap.sh
 
 verifier:
-  ruby_bindir: /opt/sensu/embedded/bin
+  ruby_bindir: <%= ENV['MY_RUBY_HOME'] || '/opt/sensu/embedded' %>/bin
 
 platforms:
   - name: ubuntu-14.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,17 @@ notifications:
     on_success: change
     on_failure: always
 script:
+- rvm use --default $TRAVIS_RUBY_VERSION
+- echo 'export PATH="$PATH:/home/travis/.rvm/bin"' | sudo tee -a /etc/profile
+- echo 'source /home/travis/.rvm/scripts/rvm' | sudo tee -a /etc/profile
 - bundle exec rake default
+- bundle exec kitchen test
+- sudo chown -R travis:travis /home/travis/.rvm
 - gem build sensu-plugins-postfix.gemspec
 - gem install sensu-plugins-postfix-*.gem
-- bundle exec kitchen test
 env:
-- KITCHEN_LOCAL_YAML=.kitchen.travis.yml
+  global:
+    - KITCHEN_LOCAL_YAML=.kitchen.travis.yml
 deploy:
   provider: rubygems
   api_key:

--- a/test/fixtures/bootstrap.sh
+++ b/test/fixtures/bootstrap.sh
@@ -1,23 +1,28 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Set up a super simple Postfix server and block its outbound port 25 so we can
 # use it for testing.
 #
 
+set -e
+
+source /etc/profile
 DATA_DIR=/tmp/kitchen/data
-SENSU_DIR=/opt/sensu
-GEM=$SENSU_DIR/embedded/bin/gem
-RUBY=$SENSU_DIR/embedded/bin/ruby
+RUBY_HOME=${MY_RUBY_HOME:-/opt/sensu/embedded}
 
-if [ ! -d $SENSU_DIR ]; then
-  wget -q http://repositories.sensuapp.org/apt/pubkey.gpg -O- | sudo apt-key add -
-  echo "deb http://repositories.sensuapp.org/apt sensu main" | sudo tee /etc/apt/sources.list.d/sensu.list
-
-  sudo apt-get update
-  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git vim postfix mailutils sensu
-  sudo iptables -I OUTPUT -m tcp -p tcp --dport 25 -j DROP
+if [ "$RUBY_HOME" = "/opt/sensu/embedded" ] && [ ! -d $RUBY_HOME ]; then
+  wget -q http://repositories.sensuapp.org/apt/pubkey.gpg -O- | apt-key add -
+  echo "deb http://repositories.sensuapp.org/apt sensu main" > /etc/apt/sources.list.d/sensu.list
+  apt-get update
+  apt-get install -y sensu
+else
+  apt-get update
 fi
 
+DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential postfix mailutils
+iptables -I OUTPUT -m tcp -p tcp --dport 25 -j DROP
+service postfix restart
+
 cd $DATA_DIR
-SIGN_GEM=false $GEM build sensu-plugins-postfix.gemspec
-sudo sensu-install -p sensu-plugins-postfix-*.gem
+SIGN_GEM=false $RUBY_HOME/bin/gem build sensu-plugins-postfix.gemspec
+$RUBY_HOME/bin/gem install sensu-plugins-postfix-*.gem

--- a/test/integration/default/bats/check-mail-delay.bats
+++ b/test/integration/default/bats/check-mail-delay.bats
@@ -1,13 +1,28 @@
 #!/usr/bin/env bats
 
 setup() {
-  export CHECK_MAIL_DELAY="sudo -u sensu /opt/sensu/embedded/bin/check-mail-delay.rb"
+  export OLD_RUBY_HOME=$RUBY_HOME
+  export OLD_GEM_HOME=$GEM_HOME
+  export OLD_GEM_PATH=$GEM_PATH
+
+  unset GEM_HOME
+  unset GEM_PATH
+  source /etc/profile
+  export RUBY_HOME=${MY_RUBY_HOME:-/opt/sensu/embedded}
+
+  INNER_GEM_HOME=$($RUBY_HOME/bin/ruby -e 'print ENV["GEM_HOME"]')
+  [ -n "$INNER_GEM_HOME" ] && GEM_BIN=$INNER_GEM_HOME/bin || GEM_BIN=$RUBY_HOME/bin
+  export CHECK="$RUBY_HOME/bin/ruby $GEM_BIN/check-mail-delay.rb"
 }
 
 teardown() {
   clear_queue
   unset_connect_timeout
   postfix reload
+
+  export RUBY_HOME=$OLD_RUBY_HOME
+  export GEM_HOME=$OLD_GEM_HOME
+  export GEM_PATH=$OLD_GEM_PATH
 }
 
 clear_queue() {

--- a/test/integration/default/bats/check-mailq.bats
+++ b/test/integration/default/bats/check-mailq.bats
@@ -1,13 +1,28 @@
 #!/usr/bin/env bats
 
 setup() {
-  export CHECK_MAILQ="sudo -u sensu /opt/sensu/embedded/bin/check-mailq.rb"
+  export OLD_RUBY_HOME=$RUBY_HOME
+  export OLD_GEM_HOME=$GEM_HOME
+  export OLD_GEM_PATH=$GEM_PATH
+
+  unset GEM_HOME
+  unset GEM_PATH
+  source /etc/profile
+  export RUBY_HOME=${MY_RUBY_HOME:-/opt/sensu/embedded}
+
+  INNER_GEM_HOME=$($RUBY_HOME/bin/ruby -e 'print ENV["GEM_HOME"]')
+  [ -n "$INNER_GEM_HOME" ] && GEM_BIN=$INNER_GEM_HOME/bin || GEM_BIN=$RUBY_HOME/bin
+  export CHECK="$RUBY_HOME/bin/ruby $GEM_BIN/check-mailq.rb"
 }
 
 teardown() {
   clear_queue
   unset_connect_timeout
   postfix reload
+
+  export RUBY_HOME=$OLD_RUBY_HOME
+  export GEM_HOME=$OLD_GEM_HOME
+  export GEM_PATH=$OLD_GEM_PATH
 }
 
 clear_queue() {


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

Mostly the same thing as
https://github.com/sensu-plugins/sensu-plugins-http/pull/60. This gets
Sensu's embedded Ruby and Travis RVM to quit stomping on each other's
environment variables and causing the integration tests to fail.

#### General

~Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)~
~Update README with any necessary configuration snippets~
~Binstubs are created if needed~
- [x] RuboCop passes
- [x] Existing tests pass 

#### New Plugins

~Tests~
~Add the plugin to the README~
~Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)~

#### Purpose

Get the integration tests back into a functioning state so plugins can be validated in CI.

#### Known Compatablity Issues

N/A